### PR TITLE
Add configuration options for server-side tagging for gtag/universal analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-radar",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Analitycs loader for vite",
   "author": "stafyniaksacha",
   "repository": "stafyniaksacha/vite-plugin-radar",

--- a/src/google-analytics.ts
+++ b/src/google-analytics.ts
@@ -11,6 +11,7 @@ type GAConfiguration = {
   send_page_view?: boolean
   allow_google_signals?: boolean
   allow_ad_personalization_signals?: boolean
+  transport_url?: string
   cookie_domain?: string
   cookie_expires?: number
   cookie_prefix?: string
@@ -20,6 +21,7 @@ type GAConfiguration = {
 
 type GoogleAnaliticsProperty = {
   id: string
+  source?: string
   disable?: boolean
   config?: GAConfiguration
   persistentValues?: Record<string, string | number | boolean>
@@ -27,7 +29,8 @@ type GoogleAnaliticsProperty = {
 
 export type GoogleAnaliticsOptions = GoogleAnaliticsProperty | GoogleAnaliticsProperty[]
 
-const GTagBase = 'https://www.googletagmanager.com/gtag/js'
+const GTagSource = 'https://www.googletagmanager.com'
+const GTagBase = (source: string) => `${source}/gtag/js`
 
 function injectTag(options: GoogleAnaliticsOptions): HtmlTagDescriptor[] {
   const tags: HtmlTagDescriptor[] = []
@@ -89,7 +92,7 @@ function injectTag(options: GoogleAnaliticsOptions): HtmlTagDescriptor[] {
   tags.push({
     tag: 'script',
     attrs: {
-      src: `${GTagBase}?id=${mainProperty.id}`,
+      src: `${GTagBase(mainProperty?.source || GTagSource)}?id=${mainProperty.id}`,
       async: true,
     },
   })


### PR DESCRIPTION
This PR adds support for those who are using server-side tagging to deploy their gtag.js script.

Overview of server-side tagging can be found [here](https://developers.google.com/tag-platform/tag-manager/server-side)

This PR focuses solely on adding the implementation for gtag, not gtm. The docs for the configuration can be found [here](https://developers.google.com/tag-platform/tag-manager/server-side/send-data)*. I personally haven't been able to get the gtm to run with my custom service, hence why I have only touched the gtag code, not the gtm code.

* Docs say just to replace domain name, however allowing for complete replace of protocol+domain allows for flexibility to those who hosting the script on the same-origin.