### PR TITLE
Fix Yandex metrica

### DIFF
--- a/src/yandex-metrica.ts
+++ b/src/yandex-metrica.ts
@@ -59,9 +59,9 @@ function injectTag(options: YandexMetricaOptions): HtmlTagDescriptor[] {
 
   for (const property of properties) {
     if (property.config)
-      template += `ym(${property.id}, ${JSON.stringify(property.config)});\n`
+      template += `ym(${property.id}, "init", ${JSON.stringify(property.config)});\n`
     else
-      template += `ym(${property.id});\n`
+      template += `ym(${property.id}, "init");\n`
 
     noscriptTemplate += `<img src="${NoScriptBase}${property.id}" style="position:absolute;left:-9999px;" alt="" />`
   }


### PR DESCRIPTION
Yandex metrica stopped delivering data after switch to vite-plugin-radar.

I checked generated version and the official documentation. The only difference I spotted is:
`ym(12345, "init", {...})` => `ym(12345, {...})`

I think this is a problem.

https://github.com/stafyniaksacha/vite-plugin-radar/blob/main/src/yandex-metrica.ts#L62
Official documentation: https://yandex.com/support/metrica/code/counter-initialize.html

NPM package: vite-plugin-radar: "0.4.1"