### PR TITLE
fix: Unbounce and TikTok malformed scripts

### DIFF
--- a/src/tiktok-pixel.ts
+++ b/src/tiktok-pixel.ts
@@ -29,7 +29,7 @@ function injectTag(options: TikTokPixelOptions): HtmlTagDescriptor[] {
   template += '!(function (w, d, t) {'
   template += 'w.TiktokAnalyticsObject = t;'
   template += 'var ttq = (w[t] = w[t] || []);'
-  template += `(ttq.methods = ${PixelMethodsAsString}),`
+  template += `(ttq.methods = [${PixelMethodsAsString}]),`
   template += '(ttq.setAndDefer = function (t, e) {'
   template += 't[e] = function () {'
   template += 't.push([e].concat(Array.prototype.slice.call(arguments, 0)));'
@@ -43,6 +43,7 @@ function injectTag(options: TikTokPixelOptions): HtmlTagDescriptor[] {
   template += '(ttq.load = function (e, n) {'
   template += `var i = ("https:" == document.location.protocol ? "https://" : "http://") + "${sourceLocation}";`
   template += '(ttq._i = ttq._i || {}), (ttq._i[e] = []), (ttq._i[e]._u = i), (ttq._t = ttq._t || {}), (ttq._t[e] = +new Date()), (ttq._o = ttq._o || {}), (ttq._o[e] = n || {});'
+  template += 'var o = document.createElement("script");'
   template += '(o.type = "text/javascript"), (o.async = !0), (o.src = i + "?sdkid=" + e + "&lib=" + t);'
   template += 'var a = document.getElementsByTagName("script")[0];'
   template += 'a.parentNode.insertBefore(o, a);'

--- a/src/unbounce.ts
+++ b/src/unbounce.ts
@@ -21,7 +21,7 @@ function injectTag(options: UnbounceOptions | true): HtmlTagDescriptor[] {
   template += '(function () {'
   template += 'var ub_script = document.createElement("script");'
   template += 'ub_script.type = "text/javascript";'
-  template += `ub_script.src = "https:" == document.location.protocol ? "https://" : "http://") + "${sourceLocation}";`
+  template += `ub_script.src = ("https:" == document.location.protocol ? "https://" : "http://") + "${sourceLocation}";`
   template += 'var s = document.getElementsByTagName("script")[0];'
   template += 's.parentNode.insertBefore(ub_script, s);'
   template += '})();'


### PR DESCRIPTION
Unfortunately my last two PRs had ever so slightly malformed scripts for Unbounce and TikTok on account of me running the snippets through a de-uglifier / de-minifier tool. I've verified that both of these scripts now work as expected.