### PR TITLE
Implement possibility to define GTM environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ export default {
           // You can set custom source for gtm script and noscript
           gtmBase: 'https://www.custom.com/gtm.js',
           nsBase: 'https://www.custom.com/ns.html',
+          // You can optionally define the environment for the gtm.
+          environment: {
+            auth: 'X1YzAB2CDEFGh3ijklmnoP',
+            preview: 'env-x',
+          },
         }
       ],
 

--- a/src/google-tag-manager.ts
+++ b/src/google-tag-manager.ts
@@ -13,6 +13,12 @@ interface GoogleTagManagerMainProperty {
 interface GoogleTagManagerDefaultProperty {
   gtmBase?: string
   nsBase?: string
+  environment?: GoogleTagManagerEnvironment
+}
+
+interface GoogleTagManagerEnvironment {
+  auth: string
+  preview: string
 }
 
 type GoogleTagManagerProperty = GoogleTagManagerMainProperty & GoogleTagManagerDefaultProperty
@@ -65,18 +71,20 @@ function injectTag(options: GoogleTagManagerOptions): HtmlTagDescriptor[] {
     children: template,
   })
 
+  const environmentAttachment = property.environment ? `&gtm_auth=${property.environment.auth}&gtm_preview=${property.environment.preview}` : "";
+    
   for (const property of properties) {
     tags.push({
       tag: 'script',
       attrs: {
-        src: `${property.gtmBase}?id=${property.id}`,
+        src: `${property.gtmBase}?id=${property.id}${environmentAttachment}`,
         async: true,
       },
     })
     tags.push({
       tag: 'noscript',
       injectTo: 'body-prepend',
-      children: `<iframe src="${property.nsBase}?id=${property.id}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
+      children: `<iframe src="${property.nsBase}?id=${property.id}${environmentAttachment}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
     })
   }
 


### PR DESCRIPTION
We would like to use the environments feature of the Google Tag Manager.
To support this the URLs in the imported scripts, need to contain the parameters gtm_auth and gtm_preview with their corresponding provided values.