### PR TITLE
fix: update google-analytics config to include debug_mode

### DIFF
--- a/src/google-analytics.ts
+++ b/src/google-analytics.ts
@@ -20,6 +20,7 @@ interface GAConfiguration extends Record<string, any> {
   user_id?: string
   page_title?: string
   currency?: string
+  debug_mode?: boolean
 }
 
 interface GAConsentDefaults {


### PR DESCRIPTION
Thanks for making a great plugin. I'm transfering our project over to use this plugin but noticed that [debug_mode](https://support.google.com/analytics/answer/7201382?hl=en#zippy=%2Cgoogle-tag-manager%2Cgoogle-tag-gtagjs) wasn't included in the GAConfiguration. 

If you do not think this is suitable for the plugin, no worries at all, please reject.

Thanks!