### PR TITLE
fix: posthog config breaking when config is not present

### DIFF
--- a/src/posthog.ts
+++ b/src/posthog.ts
@@ -43,7 +43,7 @@ function injectTag(options: PostHogAnalyticsOptions): HtmlTagDescriptor[] {
     injectTo: 'head',
     children: `
       ${ARRAY_LOADER}
-      posthog.init('${options.token}', { api_host: '${options.api_host}', ...${options.config ? JSON.stringify(options.config) : ''} })
+      posthog.init('${options.token}', { api_host: '${options.api_host}', ...${options.config ? JSON.stringify(options.config) : '{}'} })
     `,
   })
 


### PR DESCRIPTION
I've noticed Posthog was not working if the `config` attribute was not set to an empty object, as it turns out it is a simple missing `{}` in the ternary option.